### PR TITLE
Add nordbuddy to list of colorschemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ Group.new('boldFunction', colors.yellow, colors.background, groups.italicBoldFun
 - [Spacebuddy](https://github.com/Th3Whit3Wolf/spacebuddy)
 
 - [Onebuddy](https://github.com/Th3Whit3Wolf/onebuddy)
+
+- [Nordbuddy](https://github.com/maaslalani/nordbuddy)


### PR DESCRIPTION
👋  I recently discovered colorbuddy and it's super sweet! I made a [quick repository](https://github.com/maaslalani/nordbuddy) for my favourite colorscheme: [Nord](https://www.nordtheme.com/) since it currently doesn't have any support for Treesitter and lacks the latest support for the builtin LSP highlighting.

I thought I would add this repository to the colorbuddy readme in case anyone else would like to use Nord + Colorbuddy as well.

Here's a screenshot of the `Nordbuddy` theme for lua syntax (using nvim-treesitter).
![image](https://user-images.githubusercontent.com/42545625/102569296-30623c00-40b3-11eb-9f44-9d39f6aa1cfd.png)
