### PR TITLE
Add Nightbuddy to the list of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ Group.new('boldFunction', colors.yellow, colors.background, groups.italicBoldFun
 - [Spacebuddy](https://github.com/Th3Whit3Wolf/spacebuddy)
 
 - [Onebuddy](https://github.com/Th3Whit3Wolf/onebuddy)
+
+- [Nightbuddy](https://github.com/DilanGMB/nightbuddy)


### PR DESCRIPTION
Dark theme based on Dobri Next -A01- Dark of VSCode
