### PR TITLE
Fix plugin path for windows

### DIFF
--- a/lua/colorbuddy/plugins/init.lua
+++ b/lua/colorbuddy/plugins/init.lua
@@ -120,7 +120,7 @@ for _, v in ipairs(other_plugins) do
   local complete_path = vim.fn.substitute(vim.fn.fnamemodify(v, ":p"), "\\", "/", "g")
 
   local path_starts = string.find(complete_path, "colorbuddy/plugins", nil, true)
-  local relevant_path = string.sub(v, path_starts)
+  local relevant_path = string.sub(complete_path, path_starts)
 
   local individual_requirement
   individual_requirement = string.sub(relevant_path, 1, #relevant_path - 4)


### PR DESCRIPTION
The code to load the plugins, apparently incorrectly, uses the non-normaized path for the require call.
That results in \ separators on windows and throws an error.